### PR TITLE
在缺少ninja配置文件情况下处理错误问题

### DIFF
--- a/src/lib/ninja-init.js
+++ b/src/lib/ninja-init.js
@@ -6,6 +6,11 @@
  * Scaffolding webpack or gulp based project using Slush
  */
 
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+
+
 module.exports = function() {
 	console.log("ninja init!!");
 }

--- a/src/lib/ninja-start.js
+++ b/src/lib/ninja-start.js
@@ -30,6 +30,10 @@ var proxy = require('express-http-proxy');
 var socket = require('./socket');
 
 module.exports = function() {
+    if(!conf.length) {
+        console.log('Lose ninja.config file!');
+        return;
+    }
     // configure app
     app.engine('html', cons[conf.template]);
     app.set('view engine', 'html');

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -1,18 +1,17 @@
 // load conf
+var conf = {};
+
 try {
 	var file = require(process.cwd() + '/ninja.conf');
+	conf.port = file.port || 3000;
+	conf.template = file.template || 'swig';
+	conf.mock = file.mock || null;
+	conf.webpackFlag = file.webpack || false;
+	conf.proxyConf = file.proxy || null;
+	conf.staticDir = file.staticDir || null;
+	conf.templateDir = file.templateDir || null;
+	conf.browser = file.browser || 'google chrome'
 } catch (e) {
-	
+
 }
-
-var conf = {};
-conf.port = file.port || 3000;
-conf.template = file.template || 'swig';
-conf.mock = file.mock || null;
-conf.webpackFlag = file.webpack || false;
-conf.proxyConf = file.proxy || null;
-conf.staticDir = file.staticDir || null;
-conf.templateDir = file.templateDir || null;
-conf.browser = file.browser || 'google chrome'
-
 module.exports = conf;


### PR DESCRIPTION
- OSX    10.11
- Node   6.4.0

当前目录缺少ninja配置文件，会有以下报错信息：

```
conf.port = file.port || 3000;
                ^
TypeError: Cannot read property 'port' of undefined
    at Object.<anonymous> (/Users/stephenliu/Desktop/ninja/src/util/config.js:10:17)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/stephenliu/Desktop/ninja/src/lib/ninja-start.js:19:12)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
```

解决办法可以将conf对象放在try语句块中，以及需要在ninja-start，加上相应的处理错误信息。